### PR TITLE
Add support for embedded cascade files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,27 @@ nimble install facedetect
 
 ## Cascade files
 
-This library uses the same cascade file format used by Pigo. Those files available at `cascade` directory, copy it to your app folder so they can be loaded at runtime. Including them statically will be supported later.
+This library uses the same cascade file format used by Pigo. Those files available at `cascade` directory, copy it to your app folder so they can be loaded at runtime.
+
+### Including cascade file statically
+
+
+Create a constant Cascades object, then call the `initFaceDetector`,  that expects a cascades object. The facefinder, the puploc file and the lps directory paths need to be provided.
+
+```nim
+const cascades = block:
+  var result: Cascades
+  result.facefinder = staticRead("cascade/facefinder")
+  result.puploc = staticRead("cascade/puploc")
+  result.lps = initTable[string, string]()
+  for i in eyeCascades:
+    result.lps[i] = staticRead("cascade/lps/" & i)
+  for i in mouthCascades:
+    result.lps[i] = staticRead("cascade/lps/" & i)
+  result
+
+let fd = initFaceDetector(cascades)
+```
 
 ## Usage
 

--- a/src/facedetect.nim
+++ b/src/facedetect.nim
@@ -53,7 +53,6 @@ type
     eyes*: array[0..1, ref Landmark]
     landmarks*: Table[string, Landmark]
 
-  # Cascades* = tuple[facefinder: string, puploc: string]
   Cascades* = object
     facefinder*: string
     puploc*: string


### PR DESCRIPTION
The readme says including cascade files statically will be supported later. As I needed this feature, I implemented it.

I added a Cascades object that can hold the slurped files as strings.

```nim
  Cascades* = object
    facefinder*: string
    puploc*: string
    lps*: Table[string, string]
```

Then, changed the `FileStream` types to `Stream` in the `readLandmarkCascade` and the `readFaceCascade` procs, allowing `StringStream` as well. Also, I created a new `readLandmarkCascadeDir` version, that can work with the `lps` table of the Cascades object.

There is now a new `initFaceDetector` method, that expects a Cascade object and creates `StringStream` objects from the stored strings.

```nim
proc initFaceDetector*(cascades: Cascades): FaceDetector =
  result.faceCascade = readFaceCascade(newStringStream(cascades.facefinder))
  result.eyesCascade = readLandmarkCascade(newStringStream(cascades.puploc))
  result.landmarkCascades = readLandmarkCascadeDir(cascades.lps)
``` 

From a user's point of view, a constant Cascades object needs to be created, then call the `initFaceDetector` with a cascades object:
```nim
const cascades = block:
  var result: Cascades
  result.facefinder = staticRead("cascade/facefinder")
  result.puploc = staticRead("cascade/puploc")
  result.lps = initTable[string, string]()
  for i in eyeCascades:
    result.lps[i] = staticRead("cascade/lps/" & i)
  for i in mouthCascades:
    result.lps[i] = staticRead("cascade/lps/" & i)
  result

let fd = initFaceDetector(cascades)
```

This works for me, but I'm far from fluent in nim, so most and foremost I need feedback on this.
At first, I included the cascade files into the library, but in that case the binaries would large all the time. Some would not want that.
I am also not sure that defining the types as `StringStream` in the Cascades object instead of string would be better.